### PR TITLE
firedancer: integrate banking stage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b9d411ecbaf79885c6df4d75fff75858d5995ff25385657a28af47e82f9c36"
+dependencies = [
+ "unicode-width",
+ "yansi-term",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,6 +558,30 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn 2.0.31",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.66.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+dependencies = [
+ "annotate-snippets",
+ "bitflags 2.4.0",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease 0.2.14",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.31",
+ "which",
 ]
 
 [[package]]
@@ -1755,6 +1789,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "firedancer-sys"
+version = "0.3.0"
+dependencies = [
+ "bindgen 0.66.1",
+ "paste",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2612,7 +2654,7 @@ version = "0.11.0+8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
 dependencies = [
- "bindgen",
+ "bindgen 0.65.1",
  "bzip2-sys",
  "cc",
  "glob",
@@ -5216,6 +5258,7 @@ dependencies = [
  "dashmap 4.0.2",
  "eager",
  "etcd-client",
+ "firedancer-sys",
  "fs_extra",
  "histogram",
  "itertools",
@@ -5239,6 +5282,7 @@ dependencies = [
  "solana-bloom",
  "solana-client",
  "solana-entry",
+ "solana-firedancer",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-geyser-plugin-manager",
@@ -5372,6 +5416,14 @@ dependencies = [
  "spl-memo",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "solana-firedancer"
+version = "1.16.13"
+dependencies = [
+ "firedancer-sys",
+ "paste",
 ]
 
 [[package]]
@@ -8401,6 +8453,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "yansi-term"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,7 @@ env_logger = "0.9.3"
 etcd-client = "0.8.1"
 fast-math = "0.1"
 fd-lock = "3.0.12"
+firedancer-sys = { path = "../ffi/rust/firedancer-sys" }
 flate2 = "1.0.26"
 fnv = "1.0.7"
 fs_extra = "1.3.0"
@@ -242,6 +243,7 @@ num-traits = "0.2"
 once_cell = "1.13.0"
 openssl = "0.10"
 ouroboros = "0.15.6"
+paste = "1.0.12"
 parking_lot = "0.12"
 pbkdf2 = { version = "0.11.0", default-features = false }
 pem = "1.1.1"
@@ -311,6 +313,7 @@ solana-config-program = { path = "programs/config", version = "=1.16.13" }
 solana-core = { path = "core", version = "=1.16.13" }
 solana-download-utils = { path = "download-utils", version = "=1.16.13" }
 solana-entry = { path = "entry", version = "=1.16.13" }
+solana-firedancer = { path = "firedancer", version = "=1.16.13" }
 solana-faucet = { path = "faucet", version = "=1.16.13" }
 solana-frozen-abi = { path = "frozen-abi", version = "=1.16.13" }
 solana-frozen-abi-macro = { path = "frozen-abi/macro", version = "=1.16.13" }

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -452,13 +452,14 @@ fn main() {
             non_vote_receiver,
             tpu_vote_receiver,
             gossip_vote_receiver,
-            num_banking_threads,
+            // num_banking_threads,
             None,
             replay_vote_sender,
             None,
             Arc::new(connection_cache),
             bank_forks.clone(),
             &Arc::new(PrioritizationFeeCache::new(0u64)),
+            "".into(),
         );
 
         // This is so that the signal_receiver does not go out of scope after the closure.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,6 +22,7 @@ crossbeam-channel = { workspace = true }
 dashmap = { workspace = true, features = ["rayon", "raw-api"] }
 eager = { workspace = true }
 etcd-client = { workspace = true, features = ["tls"] }
+firedancer-sys = { workspace = true }
 histogram = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
@@ -39,6 +40,7 @@ solana-address-lookup-table-program = { workspace = true }
 solana-bloom = { workspace = true }
 solana-client = { workspace = true }
 solana-entry = { workspace = true }
+solana-firedancer = { workspace = true }
 solana-frozen-abi = { workspace = true }
 solana-frozen-abi-macro = { workspace = true }
 solana-geyser-plugin-manager = { workspace = true }

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -524,7 +524,7 @@ impl Consumer {
         }
     }
 
-    fn execute_and_commit_transactions_locked(
+    pub fn execute_and_commit_transactions_locked(
         &self,
         bank: &Arc<Bank>,
         batch: &TransactionBatch,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -474,6 +474,7 @@ impl Validator {
         tpu_connection_pool_size: usize,
         tpu_enable_udp: bool,
         admin_rpc_service_post_init: Arc<RwLock<Option<AdminRpcRequestMetadataPostInit>>>,
+        firedancer_app_name: String,
     ) -> Result<Self, String> {
         let id = identity_keypair.pubkey();
         assert_eq!(&id, node.info.pubkey());
@@ -1206,6 +1207,7 @@ impl Validator {
             tpu_enable_udp,
             &prioritization_fee_cache,
             config.generator_config.clone(),
+            firedancer_app_name,
         );
 
         datapoint_info!(

--- a/firedancer/Cargo.toml
+++ b/firedancer/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "solana-firedancer"
+description = "Solana Firedancer"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = "Apache-2.0"
+edition = { workspace = true }
+
+[dependencies]
+paste = { workspace = true }
+firedancer-sys = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/firedancer/src/bits.rs
+++ b/firedancer/src/bits.rs
@@ -1,0 +1,42 @@
+macro_rules! align_up {
+  ( $x:expr, $a:expr ) => {
+      ($x + ($a - 1)) & !($a - 1)
+  };
+}
+
+macro_rules! layout {
+  ( value=$value:expr, ) => { $value };
+  ( value=$value:expr, ($align:expr, $size:expr), $($tail:tt)*) => {
+      layout!( value=align_up!($value, $align) + $size, $($tail)*)
+  };
+  ( align=$align:expr, [ $($tail:tt)* ]) => {
+      align_up!(layout!(value = 0, $($tail)*), $align)
+  };
+}
+
+pub(crate) use {
+  align_up,
+  layout,
+};
+
+#[cfg(test)]
+mod tests {
+  #[test]
+  fn test_align_up() {
+      let zeros = 0u64;
+      let ones = u64::MAX;
+
+      for i in 0..64 {
+          let align = 1u64 << i;
+          let lo = (1u64 << i) - 1;
+          let hi = !lo;
+
+          assert_eq!(align_up!(zeros, align), zeros);
+          assert_eq!(align_up!(ones, align), if i == 0 { ones } else { zeros });
+          for j in 0..64 {
+              let x = 1u64 << j;
+              assert_eq!(align_up!(x, align), (x + lo) & hi);
+          }
+      }
+  }
+}

--- a/firedancer/src/cnc.rs
+++ b/firedancer/src/cnc.rs
@@ -1,0 +1,78 @@
+use std::ffi::c_ulong;
+use std::ptr::{
+    read_volatile,
+    write_volatile,
+};
+use firedancer_sys::*;
+
+use crate::*;
+
+pub struct Cnc {
+    laddr: *mut tango::fd_cnc_t,
+    diagnostic: *mut c_ulong,
+    _workspace: Workspace,
+}
+
+impl Drop for Cnc {
+    fn drop(&mut self) {
+        unsafe { tango::fd_cnc_leave(self.laddr) };
+    }
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Debug)]
+pub enum CncSignal {
+    Run = tango::FD_CNC_SIGNAL_RUN,
+    Boot = tango::FD_CNC_SIGNAL_BOOT,
+    Fail = tango::FD_CNC_SIGNAL_FAIL,
+    Halt = tango::FD_CNC_SIGNAL_HALT,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Debug)]
+pub enum CncDiag {
+    InBackpressure = tango::FD_CNC_DIAG_IN_BACKP,
+    BackpressureCount = tango::FD_CNC_DIAG_BACKP_CNT,
+}
+
+impl Cnc {
+    pub unsafe fn join<T: Into<GlobalAddress>>(gaddr: T) -> Result<Self, ()> {
+      let workspace = Workspace::map(gaddr)?;
+      let laddr = tango::fd_cnc_join(workspace.laddr.as_ptr());
+      if laddr.is_null() {
+          Err(())
+      } else {
+          let diagnostic = tango::fd_cnc_app_laddr(laddr) as *mut c_ulong;
+          if diagnostic.is_null() {
+              Err(())
+          } else {
+              Ok(Self {
+                  laddr,
+                  diagnostic,
+                  _workspace: workspace,
+              })
+          }
+      }
+  }
+
+  pub fn query(&self) -> u64 {
+      unsafe { tango::fd_cnc_signal_query(self.laddr) }
+  }
+
+  pub fn signal(&self, signal: u64) {
+      unsafe { tango::fd_cnc_signal(self.laddr, signal) }
+  }
+
+  pub unsafe fn set(&self, diag: u64, value: u64) {
+    write_volatile(self.diagnostic.offset(diag as isize), value)
+  }
+
+  pub unsafe fn increment(&self, diag: u64, value: u64) {
+      let offset = self.diagnostic.offset(diag as isize);
+      write_volatile(offset, read_volatile(offset) + value)
+  }
+
+  pub fn heartbeat(&self, now: i64) {
+      unsafe { tango::fd_cnc_heartbeat(self.laddr, now) }
+  }
+}

--- a/firedancer/src/dcache.rs
+++ b/firedancer/src/dcache.rs
@@ -1,0 +1,39 @@
+use firedancer_sys::*;
+
+use std::ffi::c_void;
+
+use crate::*;
+
+pub struct DCache {
+    laddr: *mut u8,
+    wksp: *mut util::fd_wksp_t,
+    _workspace: Workspace,
+}
+
+impl Drop for DCache {
+    fn drop(&mut self) {
+        unsafe { tango::fd_dcache_leave(self.laddr) };
+    }
+}
+
+impl DCache {
+    pub unsafe fn join<T: Into<GlobalAddress>>(gaddr: T) -> Result<Self, ()> {
+      let workspace = Workspace::map(gaddr)?;
+      let laddr = tango::fd_dcache_join(workspace.laddr.as_ptr());
+      if laddr.is_null() {
+          return Err(());
+      }
+
+      let wksp = util::fd_wksp_containing(laddr as *const c_void);
+      Ok(Self {
+          laddr,
+          wksp,
+          _workspace: workspace,
+      })
+  }
+
+  pub unsafe fn slice<'a>(&self, chunk: u64, offset: u64, len: u64) -> &'a[u8] {
+    let laddr = tango::fd_chunk_to_laddr_const(self.wksp as *const c_void, chunk);
+    std::slice::from_raw_parts(laddr.offset(offset as isize) as *const u8, len as usize)
+  }
+}

--- a/firedancer/src/fctl.rs
+++ b/firedancer/src/fctl.rs
@@ -1,0 +1,99 @@
+use std::ffi::c_void;
+use std::marker::PhantomData;
+use std::mem::{
+    align_of,
+    size_of,
+};
+use std::ptr::null_mut;
+
+use firedancer_sys::*;
+
+use crate::*;
+
+macro_rules! footprint {
+    ( $rx_max:expr ) => {
+        layout!(
+            align = tango::FD_FCTL_ALIGN as usize,
+            [
+                (
+                    align_of::<tango::fd_fctl_t>(),
+                    size_of::<tango::fd_fctl_t>()
+                ),
+                (
+                    align_of::<tango::fd_fctl_private_rx_t>(),
+                    $rx_max * size_of::<tango::fd_fctl_private_rx_t>()
+                ),
+            ]
+        )
+    };
+}
+
+pub struct FCtl<'a, 'b> {
+    _stack: Vec<u8>,
+    shmem: *mut c_void,
+    fctl: *mut tango::fd_fctl_t,
+    _seq: PhantomData<&'a u64>,
+    _slow: PhantomData<&'b mut u64>,
+}
+
+impl<'a, 'b> Drop for FCtl<'a, 'b> {
+    fn drop(&mut self) {
+        unsafe { tango::fd_fctl_leave(self.fctl) };
+        unsafe { tango::fd_fctl_delete(self.shmem) };
+    }
+}
+
+impl<'a, 'b> FCtl<'a, 'b> {
+    pub fn new(
+      cr_burst: u64,
+      cr_max: u64,
+      cr_resume: u64,
+      cr_refill: u64,
+      fseq: &FSeq,
+  ) -> Result<Self, ()> {
+      let mut stack = vec![0; footprint!(1usize)];
+      let shmem = unsafe { tango::fd_fctl_new(stack.as_mut_ptr() as *mut _, 1) };
+      if shmem.is_null() {
+          return Err(());
+      }
+
+      let fctl = unsafe { tango::fd_fctl_join(shmem) };
+      if fctl.is_null() {
+          return Err(());
+      }
+
+      let fctl = unsafe {
+          tango::fd_fctl_cfg_rx_add(
+              fctl,
+              cr_max,
+              fseq.laddr,
+              fseq.diagnostic.offset(FSeqDiag::SlowCount as isize),
+          )
+      };
+      if fctl.is_null() {
+          return Err(());
+      }
+
+      let fctl = unsafe { tango::fd_fctl_cfg_done(fctl, cr_burst, cr_max, cr_resume, cr_refill) };
+
+      Ok(FCtl {
+          _stack: stack,
+          shmem,
+          fctl,
+          _seq: PhantomData,
+          _slow: PhantomData,
+      })
+  }
+
+  pub fn tx_cr_update(&self, cr_avail: u64, mcache: &MCache) -> u64 {
+      unsafe { tango::fd_fctl_tx_cr_update(self.fctl, cr_avail, mcache.sequence_number) }
+  }
+}
+
+pub fn housekeeping_default_interval_nanos(cr_max: u64) -> i64 {
+  unsafe { util::fd_tempo_lazy_default(cr_max) }
+}
+
+pub fn minimum_housekeeping_tick_interval(lazy: i64) -> u64 {
+  unsafe { util::fd_tempo_async_min(lazy, 1, util::fd_tempo_tick_per_ns(null_mut()) as f32) }
+}

--- a/firedancer/src/fseq.rs
+++ b/firedancer/src/fseq.rs
@@ -1,0 +1,67 @@
+use std::ffi::c_ulong;
+use std::ptr::{
+    read_volatile,
+    write_volatile,
+};
+
+use firedancer_sys::*;
+
+use crate::*;
+
+pub struct FSeq {
+    pub(crate) laddr: *mut c_ulong,
+    pub(crate) diagnostic: *mut c_ulong,
+    _workspace: Workspace,
+}
+
+impl Drop for FSeq {
+    fn drop(&mut self) {
+        unsafe { tango::fd_fseq_leave(self.laddr) };
+    }
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Debug)]
+pub enum FSeqDiag {
+    PublishedCount = tango::FD_FSEQ_DIAG_PUB_CNT,
+    PublishedSize = tango::FD_FSEQ_DIAG_PUB_SZ,
+    FilteredCount = tango::FD_FSEQ_DIAG_FILT_CNT,
+    FilteredSize = tango::FD_FSEQ_DIAG_FILT_SZ,
+    OverrunPollingCount = tango::FD_FSEQ_DIAG_OVRNP_CNT,
+    OverrunReadingCount = tango::FD_FSEQ_DIAG_OVRNR_CNT,
+    SlowCount = tango::FD_FSEQ_DIAG_SLOW_CNT,
+}
+
+impl FSeq {
+    pub unsafe fn join<T: Into<GlobalAddress>>(gaddr: T) -> Result<Self, ()> {
+      let workspace = Workspace::map(gaddr)?;
+      let laddr = tango::fd_fseq_join(workspace.laddr.as_ptr());
+      if laddr.is_null() {
+          Err(())
+      } else {
+          let diagnostic = tango::fd_fseq_app_laddr(laddr) as *mut c_ulong;
+          if diagnostic.is_null() {
+              Err(())
+          } else {
+              Ok(Self {
+                  laddr,
+                  diagnostic,
+                  _workspace: workspace,
+              })
+          }
+      }
+  }
+
+  pub unsafe fn set(&self, diag: u64, value: u64) {
+      write_volatile(self.diagnostic.offset(diag as isize), value)
+  }
+
+  pub unsafe fn increment(&self, diag: u64, value: u64) {
+      let offset = self.diagnostic.offset(diag as isize);
+      write_volatile(offset, read_volatile(offset) + value)
+  }
+
+  pub fn rx_cr_return(&self, mcache: &MCache) {
+      unsafe { tango::fd_fctl_rx_cr_return(self.laddr, mcache.sequence_number) }
+  }
+}

--- a/firedancer/src/gaddr.rs
+++ b/firedancer/src/gaddr.rs
@@ -1,0 +1,41 @@
+use std::ffi::{
+  c_char,
+  CString,
+};
+
+pub struct GlobalAddress {
+  gaddr: CString,
+  _offset: u64,
+}
+
+impl GlobalAddress {
+  pub(crate) fn as_ptr(&self) -> *const c_char {
+      self.gaddr.as_ptr()
+  }
+}
+
+impl TryFrom<String> for GlobalAddress {
+  type Error = ();
+
+  fn try_from(value: String) -> Result<Self, Self::Error> {
+      let (_workspace, offset) = match value.split_once(':') {
+          None => return Err(()),
+          Some(parts) => parts,
+      };
+
+      let offset = match offset.parse() {
+          Err(_) => return Err(()),
+          Ok(offset) => offset,
+      };
+
+      let gaddr = match CString::new(value) {
+          Err(_) => return Err(()),
+          Ok(path) => path,
+      };
+
+      Ok(GlobalAddress {
+          gaddr,
+          _offset: offset,
+      })
+  }
+}

--- a/firedancer/src/lib.rs
+++ b/firedancer/src/lib.rs
@@ -1,0 +1,21 @@
+mod bits;
+mod cnc;
+mod dcache;
+mod fctl;
+mod fseq;
+mod gaddr;
+mod mcache;
+mod pod;
+mod rng;
+mod workspace;
+
+use bits::*;
+pub use cnc::*;
+pub use dcache::*;
+pub use fctl::*;
+pub use fseq::*;
+pub use gaddr::*;
+pub use mcache::*;
+pub use pod::*;
+pub use rng::*;
+pub use workspace::*;

--- a/firedancer/src/mcache.rs
+++ b/firedancer/src/mcache.rs
@@ -1,0 +1,122 @@
+use std::sync::atomic::{
+  compiler_fence,
+  Ordering,
+};
+
+use firedancer_sys::*;
+
+use crate::*;
+
+pub struct MCache {
+    laddr: *mut tango::fd_frag_meta_t,
+    mline: *mut tango::fd_frag_meta_t,
+    pub(crate) sequence_number: u64,
+    depth: u64,
+
+    sync: *mut u64,
+    _workspace: Workspace,
+}
+
+#[derive(Copy, Clone)]
+pub enum MCacheCtl {
+    None
+}
+
+impl MCacheCtl {
+  fn ctl(&self) -> u64 {
+    match self {
+        MCacheCtl::None => 0,
+    }
+  }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum Poll {
+    CaughtUp,
+    Overrun,
+    Ready,
+}
+
+#[derive(Copy, Clone)]
+  pub enum Advance {
+    Overrun,
+    Normal,
+}
+
+impl MCache {
+  pub unsafe fn join<T: Into<GlobalAddress>>(gaddr: T) -> Result<Self, ()> {
+      let workspace = Workspace::map(gaddr)?;
+      let laddr = tango::fd_mcache_join(workspace.laddr.as_ptr());
+      if laddr.is_null() {
+          return Err(());
+      }
+
+      let depth = tango::fd_mcache_depth(laddr);
+      let sync = tango::fd_mcache_seq_laddr(laddr);
+      let sequence_number = tango::fd_mcache_seq_query(sync);
+      let mline = laddr.offset(tango::fd_mcache_line_idx(sequence_number, depth) as isize);
+
+      Ok(Self {
+          laddr,
+          mline,
+          sequence_number,
+          depth,
+          sync,
+          _workspace: workspace,
+      })
+  }
+
+  pub fn depth(&self) -> u64 {
+      self.depth
+  }
+
+  pub fn chunk(&self) -> u32 {
+      unsafe { (*self.mline).__bindgen_anon_1.chunk }
+  }
+
+  pub fn housekeep(&self) {
+      unsafe { tango::fd_mcache_seq_update(self.sync, self.sequence_number) }
+  }
+
+  pub fn poll(&mut self) -> Poll {
+      compiler_fence(Ordering::AcqRel);
+      let sequence_number_found = unsafe { (*self.mline).__bindgen_anon_1.seq };
+      compiler_fence(Ordering::AcqRel);
+
+      let result: i64 = sequence_number_found.wrapping_sub(self.sequence_number) as i64;
+      if result < 0 {
+        Poll::CaughtUp
+      } else if result == 0 {
+        Poll::Ready
+      } else {
+        self.sequence_number = sequence_number_found;
+        Poll::Overrun
+      }
+  }
+
+  pub fn size(&self) -> u16 {
+    unsafe { (*self.mline).__bindgen_anon_1.sz }
+  }
+
+  pub fn advance(&mut self) -> Advance {
+      compiler_fence(Ordering::AcqRel);
+      let sequence_number_found = unsafe { (*self.mline).__bindgen_anon_1.seq };
+      compiler_fence(Ordering::AcqRel);
+
+      if sequence_number_found != self.sequence_number {
+          self.sequence_number = sequence_number_found;
+          Advance::Overrun
+      } else {
+          self.sequence_number += 1;
+          self.mline = unsafe {
+              self.laddr
+                  .offset(tango::fd_mcache_line_idx(self.sequence_number, self.depth) as isize)
+          };
+          Advance::Normal
+      }
+  }
+
+  pub fn publish(&mut self, sig: u64, chunk: u64, sz: u64, ctl: MCacheCtl, tsorig: u64, tspub: u64) {
+      unsafe { tango::fd_mcache_publish(self.mline, self.depth, self.sequence_number, sig, chunk, sz, ctl.ctl(), tsorig, tspub) }
+  }
+}

--- a/firedancer/src/pod.rs
+++ b/firedancer/src/pod.rs
@@ -1,0 +1,156 @@
+use std::ffi::{
+  c_char,
+  CStr,
+  CString, c_void,
+};
+use std::marker::PhantomData;
+use std::ptr::{null, NonNull};
+use std::sync::Arc;
+
+use firedancer_sys::*;
+use paste::paste;
+
+use crate::*;
+
+#[derive(Clone)]
+pub struct Pod {
+  laddr: *const u8,
+  workspace: Arc<Workspace>,
+}
+
+unsafe impl Send for Pod {}
+unsafe impl Sync for Pod {}
+
+impl Drop for Pod {
+  fn drop(&mut self) {
+      unsafe { util::fd_pod_leave(self.laddr) };
+  }
+}
+
+impl Pod {
+  pub unsafe fn join<T: TryInto<GlobalAddress>>(gaddr: T) -> Result<Self, ()> {
+      let workspace = Workspace::map(gaddr)?;
+      let laddr = util::fd_pod_join(workspace.laddr.as_ptr());
+      if laddr.is_null() {
+          Err(())
+      } else {
+          Ok(Self {
+              laddr,
+              workspace: Arc::new(workspace),
+          })
+      }
+  }
+
+  pub unsafe fn join_default<T: AsRef<str>>(wksp: T) -> Result<Self, ()> {
+      let wksp_str = CString::new(wksp.as_ref()).unwrap();
+      let wksp = util::fd_wksp_attach(wksp_str.as_ptr());
+      if wksp.is_null() {
+          return Err(());
+      }
+
+      let pod = util::fd_wksp_laddr( wksp, (*wksp).gaddr_lo );
+      if pod.is_null() {
+          return Err(());
+      }
+
+      let laddr = util::fd_pod_join(pod);
+
+      if laddr.is_null() {
+          Err(())
+      } else {
+          Ok(Self {
+              laddr,
+              workspace: Arc::new(Workspace {
+                  laddr: NonNull::new(laddr as *mut c_void).unwrap(),
+                  _marker: PhantomData,
+              }),
+          })
+      }
+  }
+
+  pub fn try_query<T: FromPod, S: AsRef<str>>(&self, key: S) -> Option<T> {
+      let key = match CString::new(key.as_ref()) {
+          Ok(key) => key,
+          _ => return None,
+      };
+
+      T::try_query(self, key.as_ptr())
+  }
+
+  pub fn query<T: FromPod + Default, S: AsRef<str>>(&self, key: S) -> T {
+      let key = match CString::new(key.as_ref()) {
+          Ok(key) => key,
+          _ => return T::default(),
+      };
+
+      T::query(self, key.as_ptr())
+  }
+}
+
+pub trait FromPod: Sized {
+  fn try_query(pod: &Pod, key: *const c_char) -> Option<Self>;
+
+  fn query(pod: &Pod, key: *const c_char) -> Self {
+      FromPod::try_query(pod, key).unwrap()
+  }
+}
+
+impl FromPod for String {
+  fn try_query(pod: &Pod, key: *const c_char) -> Option<Self> {
+      let value = unsafe { util::fd_pod_query_cstr(pod.laddr, key, null()) } as *const i8;
+
+      if value.is_null() {
+          return None;
+      }
+
+      match unsafe { CStr::from_ptr(value).to_str() } {
+          Ok(str) => Some(str.to_owned()),
+          _ => None,
+      }
+  }
+}
+
+impl FromPod for Pod {
+  fn try_query(pod: &Pod, key: *const c_char) -> Option<Self> {
+      let laddr = unsafe { util::fd_pod_query_subpod(pod.laddr, key) };
+
+      if laddr.is_null() {
+          return None;
+      }
+
+      Some(Pod {
+          laddr,
+          workspace: pod.workspace.clone(),
+      })
+  }
+}
+
+impl FromPod for GlobalAddress {
+  fn try_query(pod: &Pod, key: *const c_char) -> Option<Self> {
+      let string: String = FromPod::try_query(pod, key)?;
+      string.try_into().ok()
+  }
+}
+
+macro_rules! impl_from_pod {
+  ($ty:ty, $id:ident) => {
+      impl FromPod for $ty {
+          fn try_query(pod: &Pod, key: *const c_char) -> Option<Self> {
+              paste! {
+                  unsafe {
+                      Some(util::[<fd_pod_query_ $id>](pod.laddr, key, $ty::default()))
+                  }
+              }
+          }
+      }
+  };
+}
+
+impl_from_pod!(i8, char);
+impl_from_pod!(i16, short);
+impl_from_pod!(i32, int);
+impl_from_pod!(i64, long);
+impl_from_pod!(u8, uchar);
+impl_from_pod!(u16, ushort);
+impl_from_pod!(u32, uint);
+impl_from_pod!(u64, ulong);

--- a/firedancer/src/rng.rs
+++ b/firedancer/src/rng.rs
@@ -1,0 +1,44 @@
+use std::ffi::c_void;
+
+use firedancer_sys::*;
+
+pub struct Rng {
+    inner: util::fd_rng_t,
+    shmem: *mut c_void,
+}
+
+impl Drop for Rng {
+    fn drop(&mut self) {
+        unsafe { util::fd_rng_leave(&mut self.inner) };
+        unsafe { util::fd_rng_delete(self.shmem) };
+    }
+}
+
+impl Rng {
+    pub fn new(seed: u32, id: u64) -> Result<Self, ()> {
+        let mut inner = util::fd_rng_t { seq: 0, idx: 0 };
+
+        let shmem = unsafe { util::fd_rng_new(&mut inner as *mut _ as *mut c_void, seed, id) };
+        if shmem.is_null() {
+            return Err(());
+        }
+
+        let rng = unsafe { util::fd_rng_join(shmem) };
+        if rng.is_null() {
+            return Err(());
+        }
+
+        Ok(Rng { inner, shmem })
+    }
+
+    pub fn async_reload(&mut self, min: u64) -> u64 {
+        unsafe { util::fd_tempo_async_reload(&mut self.inner, min) }
+    }
+}
+
+pub fn boot() {
+    let mut argc: i32 = 0;
+    unsafe {
+        util::fd_boot(&mut argc as *mut _, std::ptr::null_mut());
+    }
+}

--- a/firedancer/src/workspace.rs
+++ b/firedancer/src/workspace.rs
@@ -1,0 +1,37 @@
+use std::cell::Cell;
+use std::ffi::c_void;
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+
+use firedancer_sys::*;
+
+use crate::*;
+
+pub struct Workspace {
+    pub(crate) laddr: NonNull<c_void>,
+    pub(crate) _marker: PhantomData<Cell<c_void>>, // Not covariant
+}
+
+impl Drop for Workspace {
+    fn drop(&mut self) {
+        unsafe { firedancer_sys::util::fd_wksp_unmap(self.laddr.as_ptr()) }
+    }
+}
+
+impl Workspace {
+    pub(crate) unsafe fn map<G: TryInto<GlobalAddress>>(gaddr: G) -> Result<Self, ()> {
+        let addr: GlobalAddress = match gaddr.try_into() {
+            Ok(addr) => addr,
+            _ => return Err(()),
+        };
+        let laddr = unsafe { util::fd_wksp_map(addr.as_ptr()) };
+        if laddr.is_null() {
+            Err(())
+        } else {
+            Ok(Self {
+                laddr: NonNull::new(laddr).unwrap(),
+                _marker: PhantomData,
+            })
+        }
+    }
+}

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2841,8 +2841,8 @@ pub struct Sockets {
     pub retransmit_sockets: Vec<UdpSocket>,
     pub serve_repair: UdpSocket,
     pub ancestor_hashes_requests: UdpSocket,
-    pub tpu_quic: UdpSocket,
-    pub tpu_forwards_quic: UdpSocket,
+    pub tpu_quic: Option<UdpSocket>,
+    pub tpu_forwards_quic: Option<UdpSocket>,
 }
 
 #[derive(Debug)]
@@ -2932,8 +2932,8 @@ impl Node {
                 retransmit_sockets: vec![retransmit_socket],
                 serve_repair,
                 ancestor_hashes_requests,
-                tpu_quic,
-                tpu_forwards_quic,
+                tpu_quic: Some(tpu_quic),
+                tpu_forwards_quic: Some(tpu_forwards_quic),
             },
         }
     }
@@ -3023,8 +3023,8 @@ impl Node {
                 retransmit_sockets: vec![retransmit_socket],
                 serve_repair,
                 ancestor_hashes_requests,
-                tpu_quic,
-                tpu_forwards_quic,
+                tpu_quic: Some(tpu_quic),
+                tpu_forwards_quic: Some(tpu_forwards_quic),
             },
         }
     }
@@ -3036,6 +3036,7 @@ impl Node {
         bind_ip_addr: IpAddr,
         public_tpu_addr: Option<SocketAddr>,
         public_tpu_forwards_addr: Option<SocketAddr>,
+        tpu_port: u16,
     ) -> Node {
         let (gossip_port, (gossip, ip_echo)) =
             Self::get_gossip_port(gossip_addr, port_range, bind_ip_addr);
@@ -3046,6 +3047,7 @@ impl Node {
         let (tvu_forwards_port, tvu_forwards_sockets) =
             multi_bind_in_range(bind_ip_addr, port_range, 8).expect("tvu_forwards multi_bind");
 
+        /*
         let (tpu_port, tpu_sockets) =
             multi_bind_in_range(bind_ip_addr, port_range, 32).expect("tpu multi_bind");
 
@@ -3067,6 +3069,7 @@ impl Node {
 
         let (tpu_vote_port, tpu_vote_sockets) =
             multi_bind_in_range(bind_ip_addr, port_range, 1).expect("tpu_vote multi_bind");
+        */
 
         let (_, retransmit_sockets) =
             multi_bind_in_range(bind_ip_addr, port_range, 8).expect("retransmit multi_bind");
@@ -3091,9 +3094,9 @@ impl Node {
         let _ = info.set_repair((addr, repair_port));
         let _ = info.set_tpu(public_tpu_addr.unwrap_or_else(|| SocketAddr::new(addr, tpu_port)));
         let _ = info.set_tpu_forwards(
-            public_tpu_forwards_addr.unwrap_or_else(|| SocketAddr::new(addr, tpu_forwards_port)),
+            public_tpu_forwards_addr.unwrap_or_else(|| SocketAddr::new(addr, tpu_port)),
         );
-        let _ = info.set_tpu_vote((addr, tpu_vote_port));
+        let _ = info.set_tpu_vote((addr, tpu_port));
         let _ = info.set_serve_repair((addr, serve_repair_port));
         trace!("new ContactInfo: {:?}", info);
 
@@ -3103,17 +3106,17 @@ impl Node {
                 gossip,
                 tvu: tvu_sockets,
                 tvu_forwards: tvu_forwards_sockets,
-                tpu: tpu_sockets,
-                tpu_forwards: tpu_forwards_sockets,
-                tpu_vote: tpu_vote_sockets,
+                tpu: vec![], // tpu_sockets,
+                tpu_forwards: vec![], // tpu_forwards_sockets,
+                tpu_vote: vec![], // tpu_vote_sockets,
                 broadcast,
                 repair,
                 retransmit_sockets,
                 serve_repair,
                 ip_echo: Some(ip_echo),
                 ancestor_hashes_requests,
-                tpu_quic,
-                tpu_forwards_quic,
+                tpu_quic: None,
+                tpu_forwards_quic: None,
             },
         }
     }

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -279,6 +279,7 @@ impl LocalCluster {
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             DEFAULT_TPU_ENABLE_UDP,
             Arc::new(RwLock::new(None)),
+            "".into(),
         )
         .expect("assume successful validator start");
 
@@ -494,6 +495,7 @@ impl LocalCluster {
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             DEFAULT_TPU_ENABLE_UDP,
             Arc::new(RwLock::new(None)),
+            "".into(),
         )
         .expect("assume successful validator start");
 
@@ -887,6 +889,7 @@ impl Cluster for LocalCluster {
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             DEFAULT_TPU_ENABLE_UDP,
             Arc::new(RwLock::new(None)),
+            "".into(),
         )
         .expect("assume successful validator start");
         cluster_validator_info.validator = Some(restarted_node);

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -976,6 +976,7 @@ impl TestValidator {
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
             config.tpu_enable_udp,
             config.admin_rpc_service_post_init.clone(),
+            "".into(),
         )?);
 
         // Needed to avoid panics in `solana-responder-gossip` in tests that create a number of

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -86,11 +86,15 @@ fn verify_reachable_ports(
     }
     if verify_address(&node.info.tpu(Protocol::UDP).ok()) {
         udp_sockets.extend(node.sockets.tpu.iter());
-        udp_sockets.push(&node.sockets.tpu_quic);
+        if let Some(tpu_quic) = node.sockets.tpu_quic.as_ref() {
+            udp_sockets.push(tpu_quic);
+        }
     }
     if verify_address(&node.info.tpu_forwards(Protocol::UDP).ok()) {
         udp_sockets.extend(node.sockets.tpu_forwards.iter());
-        udp_sockets.push(&node.sockets.tpu_forwards_quic);
+        if let Some(tpu_forwards_quic) = node.sockets.tpu_forwards_quic.as_ref() {
+            udp_sockets.push(tpu_forwards_quic);
+        }
     }
     if verify_address(&node.info.tpu_vote().ok()) {
         udp_sockets.extend(node.sockets.tpu_vote.iter());

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -100,6 +100,13 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                        --identity keypair or with the --authorized-voter argument")
         )
         .arg(
+            Arg::with_name("firedancer_app_name")
+                .long("firedancer-app-name")
+                .value_name("NAME")
+                .takes_value(true)
+                .help("Name of this firedancer app")
+        )
+        .arg(
             Arg::with_name("init_complete_file")
                 .long("init-complete-file")
                 .value_name("FILE")
@@ -800,6 +807,13 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .long("tpu-enable-udp")
                 .takes_value(false)
                 .help("Enable UDP for receiving/sending transactions."),
+        )
+        .arg(
+            Arg::with_name("tpu_port")
+                .long("tpu-port")
+                .takes_value(true)
+                .validator(is_parsable::<u16>)
+                .help("Port to use for receiving transactions in the TPU."),
         )
         .arg(
             Arg::with_name("tpu_connection_pool_size")

--- a/validator/src/main1.rs
+++ b/validator/src/main1.rs
@@ -1052,6 +1052,8 @@ where
         DEFAULT_TPU_ENABLE_UDP
     };
 
+    let tpu_port = value_t_or_exit!(matches, "tpu_port", u16);
+
     let tpu_connection_pool_size = value_t_or_exit!(matches, "tpu_connection_pool_size", usize);
 
     let shrink_ratio = value_t_or_exit!(matches, "accounts_shrink_ratio", f64);
@@ -1772,6 +1774,7 @@ where
         bind_address,
         public_tpu_addr,
         public_tpu_forwards_addr,
+        tpu_port,
     );
 
     if restricted_repair_only_mode {
@@ -1849,6 +1852,8 @@ where
         return;
     }
 
+    let firedancer_app_name = value_t_or_exit!(matches, "firedancer_app_name", String);
+
     let validator = Validator::new(
         node,
         identity_keypair,
@@ -1865,6 +1870,7 @@ where
         tpu_connection_pool_size,
         tpu_enable_udp,
         admin_service_post_init,
+        firedancer_app_name,
     )
     .unwrap_or_else(|e| {
         error!("Failed to start validator: {:?}", e);


### PR DESCRIPTION
The banking stage of the TPU is switched over to be a Firedancer tile, reading from an mcache/dcache produced by the pack tile. The pack tile makes certain guarantees for packed micro-blocks, particularly that the accounts will be lockable (not already scheduled), and non-conflicting, and also that the resource limits will not be exceeded.