### PR TITLE
firedancer: communicate working bank slot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5948,6 +5948,7 @@ dependencies = [
  "matches",
  "rand 0.7.3",
  "solana-entry",
+ "solana-firedancer",
  "solana-ledger",
  "solana-logger",
  "solana-measure",

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -876,6 +876,7 @@ impl Validator {
                 &genesis_config.poh_config,
                 Some(poh_timing_point_sender),
                 exit.clone(),
+                firedancer_app_name.clone(),
             )
         };
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));

--- a/firedancer/src/lib.rs
+++ b/firedancer/src/lib.rs
@@ -8,6 +8,7 @@ mod mcache;
 mod mvcc;
 mod pod;
 mod rng;
+mod ulong;
 mod workspace;
 
 use bits::*;
@@ -20,4 +21,5 @@ pub use mcache::*;
 pub use mvcc::*;
 pub use pod::*;
 pub use rng::*;
+pub use ulong::*;
 pub use workspace::*;

--- a/firedancer/src/ulong.rs
+++ b/firedancer/src/ulong.rs
@@ -1,0 +1,24 @@
+use crate::*;
+
+pub struct ULong {
+    pub value: *mut u64,
+    _workspace: Workspace,
+}
+
+impl ULong {
+    pub unsafe fn join<T: Into<GlobalAddress>>(gaddr: T) -> Result<Self, ()> {
+        let workspace = Workspace::map(gaddr)?;
+        let laddr = workspace.laddr.as_ptr() as *mut u64;
+        if laddr.is_null() {
+            Err(())
+        } else {
+            Ok(Self {
+                value: laddr,
+                _workspace: workspace,
+            })
+        }
+    }
+}
+
+unsafe impl Send for ULong {}
+unsafe impl Sync for ULong {}

--- a/poh/Cargo.toml
+++ b/poh/Cargo.toml
@@ -14,6 +14,7 @@ core_affinity = { workspace = true }
 crossbeam-channel = { workspace = true }
 log = { workspace = true }
 solana-entry = { workspace = true }
+solana-firedancer = { workspace = true }
 solana-ledger = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }


### PR DESCRIPTION
Solana Labs is currently responsible for the proof of history, but Firedancer is packing blocks for execution. To pack correctly, our validator needs to know when it is the leader or not.

It also needs to know the current slot that we are the leader for, so that it can "finish" packing the current block when we are no longer the leader or the slot changes.