### PR TITLE
firedancer: communicate cluster contact info

### DIFF
--- a/core/src/cluster_nodes.rs
+++ b/core/src/cluster_nodes.rs
@@ -46,7 +46,7 @@ pub enum Error {
 }
 
 #[allow(clippy::large_enum_variant)]
-enum NodeId {
+pub enum NodeId {
     // TVU node obtained through gossip (staked or not).
     ContactInfo(ContactInfo),
     // Staked node with no contact-info in gossip table.
@@ -54,15 +54,15 @@ enum NodeId {
 }
 
 pub struct Node {
-    node: NodeId,
-    stake: u64,
+    pub node: NodeId,
+    pub stake: u64,
 }
 
 pub struct ClusterNodes<T> {
     pubkey: Pubkey, // The local node itself.
     // All staked nodes + other known tvu-peers + the node itself;
     // sorted by (stake, pubkey) in descending order.
-    nodes: Vec<Node>,
+    pub nodes: Vec<Node>,
     // Reverse index from nodes pubkey to their index in self.nodes.
     index: HashMap<Pubkey, /*index:*/ usize>,
     weighted_shuffle: WeightedShuffle</*stake:*/ u64>,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -138,6 +138,7 @@ impl Tvu {
         connection_cache: &Arc<ConnectionCache>,
         prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
         banking_tracer: Arc<BankingTracer>,
+        firedancer_app_name: String,
     ) -> Result<Self, String> {
         let TvuSockets {
             repair: repair_socket,
@@ -306,6 +307,7 @@ impl Tvu {
             dumped_slots_sender,
             banking_tracer,
             popular_pruned_forks_receiver,
+            firedancer_app_name,
         )?;
 
         let ledger_cleanup_service = tvu_config.max_ledger_shreds.map(|max_ledger_shreds| {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1167,6 +1167,7 @@ impl Validator {
             &connection_cache,
             &prioritization_fee_cache,
             banking_tracer.clone(),
+            firedancer_app_name.clone(),
         )?;
 
         let tpu = Tpu::new(

--- a/gossip/src/legacy_contact_info.rs
+++ b/gossip/src/legacy_contact_info.rs
@@ -20,11 +20,11 @@ use {
     Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, AbiExample, Deserialize, Serialize,
 )]
 pub struct LegacyContactInfo {
-    id: Pubkey,
+    pub id: Pubkey,
     /// gossip address
     gossip: SocketAddr,
     /// address to connect to for replication
-    tvu: SocketAddr,
+    pub tvu: SocketAddr,
     /// address to forward shreds to
     tvu_forwards: SocketAddr,
     /// address to send repair responses to


### PR DESCRIPTION
The Firedancer shredder needs to know which nodes in the cluster to forward shreds to, which information is currently maintained by the Solana Labs cluster info. For now, we communicate this across the IPC boundary.