### PR TITLE
firedancer: send to new shredder via. mcache

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -579,7 +579,7 @@ impl BankingStage {
         use core::arch::x86::_rdtsc as rdtsc;
 
         let mut in_mcache = MCache::join::<GlobalAddress>(in_pod.try_query(format!("mcache{}", id)).unwrap()).unwrap();
-        let in_dcache = DCache::join::<GlobalAddress>(in_pod.try_query(format!("dcache{}", id)).unwrap()).unwrap();
+        let in_dcache = DCache::join::<GlobalAddress>(in_pod.try_query(format!("dcache{}", id)).unwrap(), 0).unwrap(); /* MTU doesn't matter, we are only a reader */
         let in_fseq = FSeq::join::<GlobalAddress>(in_pod.try_query(format!("fseq{}", id)).unwrap()).unwrap();
 
         in_fseq.set(FSeqDiag::PublishedCount as u64, 0);

--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -57,7 +57,7 @@ const CLUSTER_NODES_CACHE_NUM_EPOCH_CAP: usize = 8;
 const CLUSTER_NODES_CACHE_TTL: Duration = Duration::from_secs(5);
 
 pub(crate) const NUM_INSERT_THREADS: usize = 2;
-pub(crate) type RetransmitSlotsSender = Sender<Slot>;
+// pub(crate) type RetransmitSlotsSender = Sender<Slot>;
 pub(crate) type RetransmitSlotsReceiver = Receiver<Slot>;
 pub(crate) type RecordReceiver = Receiver<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>;
 pub(crate) type TransmitReceiver = Receiver<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -74,7 +74,7 @@ mod tower1_14_11;
 mod tower1_7_14;
 pub mod tower_storage;
 pub mod tpu;
-mod tpu_entry_notifier;
+// mod tpu_entry_notifier;
 pub mod tracer_packet_stats;
 pub mod tree_diff;
 pub mod tvu;

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4,7 +4,7 @@ use {
     crate::{
         ancestor_hashes_service::AncestorHashesReplayUpdateSender,
         banking_trace::BankingTracer,
-        broadcast_stage::RetransmitSlotsSender,
+        // broadcast_stage::RetransmitSlotsSender,
         cache_block_meta_service::CacheBlockMetaSender,
         cluster_info_vote_listener::{
             GossipDuplicateConfirmedSlotsReceiver, GossipVerifiedVoteHashReceiver, VoteTracker,
@@ -50,7 +50,7 @@ use {
         },
         entry_notifier_service::EntryNotifierSender,
         leader_schedule_cache::LeaderScheduleCache,
-        leader_schedule_utils::first_of_consecutive_leader_slots,
+        // leader_schedule_utils::first_of_consecutive_leader_slots,
     },
     solana_measure::measure::Measure,
     solana_poh::poh_recorder::{PohLeaderStatus, PohRecorder, GRACE_TICKS_FACTOR, MAX_GRACE_SLOTS},
@@ -165,7 +165,7 @@ struct LastVoteRefreshTime {
 
 #[derive(Default)]
 struct SkippedSlotsInfo {
-    last_retransmit_slot: u64,
+    // last_retransmit_slot: u64,
     last_skipped_slot: u64,
 }
 
@@ -491,7 +491,7 @@ impl ReplayStage {
         maybe_process_blockstore: Option<ProcessBlockStore>,
         vote_tracker: Arc<VoteTracker>,
         cluster_slots: Arc<ClusterSlots>,
-        retransmit_slots_sender: RetransmitSlotsSender,
+        // retransmit_slots_sender: RetransmitSlotsSender,
         ancestor_duplicate_slots_receiver: AncestorDuplicateSlotsReceiver,
         replay_vote_sender: ReplayVoteSender,
         gossip_duplicate_confirmed_slots_receiver: GossipDuplicateConfirmedSlotsReceiver,
@@ -1036,11 +1036,11 @@ impl ReplayStage {
 
                 let mut retransmit_not_propagated_time =
                     Measure::start("retransmit_not_propagated_time");
-                Self::retransmit_latest_unpropagated_leader_slot(
-                    &poh_recorder,
-                    &retransmit_slots_sender,
-                    &mut progress,
-                );
+                // Self::retransmit_latest_unpropagated_leader_slot(
+                //     &poh_recorder,
+                //     &retransmit_slots_sender,
+                //     &mut progress,
+                // );
                 retransmit_not_propagated_time.stop();
 
                 // From this point on, its not safe to use ancestors/descendants since maybe_start_leader
@@ -1055,7 +1055,7 @@ impl ReplayStage {
                         &leader_schedule_cache,
                         &rpc_subscriptions,
                         &mut progress,
-                        &retransmit_slots_sender,
+                        // &retransmit_slots_sender,
                         &mut skipped_slots_info,
                         &banking_tracer,
                         has_new_vote_been_rooted,
@@ -1160,68 +1160,68 @@ impl ReplayStage {
         }
     }
 
-    fn maybe_retransmit_unpropagated_slots(
-        metric_name: &'static str,
-        retransmit_slots_sender: &RetransmitSlotsSender,
-        progress: &mut ProgressMap,
-        latest_leader_slot: Slot,
-    ) {
-        let first_leader_group_slot = first_of_consecutive_leader_slots(latest_leader_slot);
+    // fn maybe_retransmit_unpropagated_slots(
+    //     metric_name: &'static str,
+    //     retransmit_slots_sender: &RetransmitSlotsSender,
+    //     progress: &mut ProgressMap,
+    //     latest_leader_slot: Slot,
+    // ) {
+    //     let first_leader_group_slot = first_of_consecutive_leader_slots(latest_leader_slot);
+    //
+    //     for slot in first_leader_group_slot..=latest_leader_slot {
+    //         let is_propagated = progress.is_propagated(slot);
+    //         if let Some(retransmit_info) = progress.get_retransmit_info_mut(slot) {
+    //             if !is_propagated.expect(
+    //                 "presence of retransmit_info ensures that propagation status is present",
+    //             ) {
+    //                 if retransmit_info.reached_retransmit_threshold() {
+    //                     info!(
+    //                         "Retrying retransmit: latest_leader_slot={} slot={} retransmit_info={:?}",
+    //                         latest_leader_slot,
+    //                         slot,
+    //                         &retransmit_info,
+    //                     );
+    //                     datapoint_info!(
+    //                         metric_name,
+    //                         ("latest_leader_slot", latest_leader_slot, i64),
+    //                         ("slot", slot, i64),
+    //                         ("retry_iteration", retransmit_info.retry_iteration, i64),
+    //                     );
+    //                     let _ = retransmit_slots_sender.send(slot);
+    //                     retransmit_info.increment_retry_iteration();
+    //                 } else {
+    //                     debug!(
+    //                         "Bypass retransmit of slot={} retransmit_info={:?}",
+    //                         slot, &retransmit_info
+    //                     );
+    //                 }
+    //             }
+    //         }
+    //     }
+    // }
 
-        for slot in first_leader_group_slot..=latest_leader_slot {
-            let is_propagated = progress.is_propagated(slot);
-            if let Some(retransmit_info) = progress.get_retransmit_info_mut(slot) {
-                if !is_propagated.expect(
-                    "presence of retransmit_info ensures that propagation status is present",
-                ) {
-                    if retransmit_info.reached_retransmit_threshold() {
-                        info!(
-                            "Retrying retransmit: latest_leader_slot={} slot={} retransmit_info={:?}",
-                            latest_leader_slot,
-                            slot,
-                            &retransmit_info,
-                        );
-                        datapoint_info!(
-                            metric_name,
-                            ("latest_leader_slot", latest_leader_slot, i64),
-                            ("slot", slot, i64),
-                            ("retry_iteration", retransmit_info.retry_iteration, i64),
-                        );
-                        let _ = retransmit_slots_sender.send(slot);
-                        retransmit_info.increment_retry_iteration();
-                    } else {
-                        debug!(
-                            "Bypass retransmit of slot={} retransmit_info={:?}",
-                            slot, &retransmit_info
-                        );
-                    }
-                }
-            }
-        }
-    }
-
-    fn retransmit_latest_unpropagated_leader_slot(
-        poh_recorder: &Arc<RwLock<PohRecorder>>,
-        retransmit_slots_sender: &RetransmitSlotsSender,
-        progress: &mut ProgressMap,
-    ) {
-        let start_slot = poh_recorder.read().unwrap().start_slot();
-
-        if let (false, Some(latest_leader_slot)) =
-            progress.get_leader_propagation_slot_must_exist(start_slot)
-        {
-            debug!(
-                "Slot not propagated: start_slot={} latest_leader_slot={}",
-                start_slot, latest_leader_slot
-            );
-            Self::maybe_retransmit_unpropagated_slots(
-                "replay_stage-retransmit-timing-based",
-                retransmit_slots_sender,
-                progress,
-                latest_leader_slot,
-            );
-        }
-    }
+    // fn retransmit_latest_unpropagated_leader_slot(
+    //     poh_recorder: &Arc<RwLock<PohRecorder>>,
+    //     retransmit_slots_sender: &RetransmitSlotsSender,
+    //     progress: &mut ProgressMap,
+    // ) {
+    //     let start_slot = poh_recorder.read().unwrap().start_slot();
+    //
+    //     if let (false, Some(latest_leader_slot)) =
+    //         progress.get_leader_propagation_slot_must_exist(start_slot)
+    //     {
+    //         debug!(
+    //             "Slot not propagated: start_slot={} latest_leader_slot={}",
+    //             start_slot, latest_leader_slot
+    //         );
+    //         Self::maybe_retransmit_unpropagated_slots(
+    //             "replay_stage-retransmit-timing-based",
+    //             retransmit_slots_sender,
+    //             progress,
+    //             latest_leader_slot,
+    //         );
+    //     }
+    // }
 
     fn is_partition_detected(
         ancestors: &HashMap<Slot, HashSet<Slot>>,
@@ -1815,16 +1815,16 @@ impl ReplayStage {
             .0
     }
 
-    fn should_retransmit(poh_slot: Slot, last_retransmit_slot: &mut Slot) -> bool {
-        if poh_slot < *last_retransmit_slot
-            || poh_slot >= *last_retransmit_slot + NUM_CONSECUTIVE_LEADER_SLOTS
-        {
-            *last_retransmit_slot = poh_slot;
-            true
-        } else {
-            false
-        }
-    }
+    // fn should_retransmit(poh_slot: Slot, last_retransmit_slot: &mut Slot) -> bool {
+    //     if poh_slot < *last_retransmit_slot
+    //         || poh_slot >= *last_retransmit_slot + NUM_CONSECUTIVE_LEADER_SLOTS
+    //     {
+    //         *last_retransmit_slot = poh_slot;
+    //         true
+    //     } else {
+    //         false
+    //     }
+    // }
 
     #[allow(clippy::too_many_arguments)]
     fn maybe_start_leader(
@@ -1834,7 +1834,7 @@ impl ReplayStage {
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
         rpc_subscriptions: &Arc<RpcSubscriptions>,
         progress_map: &mut ProgressMap,
-        retransmit_slots_sender: &RetransmitSlotsSender,
+        // retransmit_slots_sender: &RetransmitSlotsSender,
         skipped_slots_info: &mut SkippedSlotsInfo,
         banking_tracer: &Arc<BankingTracer>,
         has_new_vote_been_rooted: bool,
@@ -1925,14 +1925,14 @@ impl ReplayStage {
                     progress_map.log_propagated_stats(latest_unconfirmed_leader_slot, bank_forks);
                     skipped_slots_info.last_skipped_slot = poh_slot;
                 }
-                if Self::should_retransmit(poh_slot, &mut skipped_slots_info.last_retransmit_slot) {
-                    Self::maybe_retransmit_unpropagated_slots(
-                        "replay_stage-retransmit",
-                        retransmit_slots_sender,
-                        progress_map,
-                        latest_unconfirmed_leader_slot,
-                    );
-                }
+                // if Self::should_retransmit(poh_slot, &mut skipped_slots_info.last_retransmit_slot) {
+                //     Self::maybe_retransmit_unpropagated_slots(
+                //         "replay_stage-retransmit",
+                //         retransmit_slots_sender,
+                //         progress_map,
+                //         latest_unconfirmed_leader_slot,
+                //     );
+                // }
                 return;
             }
 
@@ -7114,7 +7114,7 @@ pub(crate) mod tests {
         assert_eq!(tower.last_voted_slot().unwrap(), 1);
     }
 
-    #[test]
+    /* #[test]
     fn test_retransmit_latest_unpropagated_leader_slot() {
         let ReplayBlockstoreComponents {
             validator_node_to_vote_keys,
@@ -7281,7 +7281,7 @@ pub(crate) mod tests {
             4,
             "retransmit should advance retry_iteration"
         );
-    }
+    }*/
 
     fn receive_slots(retransmit_slots_receiver: &RetransmitSlotsReceiver) -> Vec<Slot> {
         let mut slots = Vec::default();

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -6,7 +6,7 @@ use {
     crate::{
         banking_stage::BankingStage,
         banking_trace::{BankingTracer, TracerThread},
-        broadcast_stage::{BroadcastStage, BroadcastStageType, RetransmitSlotsReceiver},
+        // broadcast_stage::{BroadcastStage, BroadcastStageType, RetransmitSlotsReceiver},
         cluster_info_vote_listener::{
             ClusterInfoVoteListener, GossipDuplicateConfirmedSlotsSender,
             GossipVerifiedVoteHashSender, VerifiedVoteSender, VoteTracker,
@@ -15,17 +15,17 @@ use {
         sigverify::TransactionSigVerifier,
         sigverify_stage::SigVerifyStage,
         staked_nodes_updater_service::StakedNodesUpdaterService,
-        tpu_entry_notifier::TpuEntryNotifier,
+        // tpu_entry_notifier::TpuEntryNotifier,
         validator::GeneratorConfig,
     },
-    crossbeam_channel::{unbounded, Receiver},
+    crossbeam_channel::{unbounded/* , Receiver*/},
     solana_client::connection_cache::{ConnectionCache, Protocol},
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::{
         blockstore::Blockstore, blockstore_processor::TransactionStatusSender,
-        entry_notifier_service::EntryNotifierSender,
+        // entry_notifier_service::EntryNotifierSender,
     },
-    solana_poh::poh_recorder::{PohRecorder, WorkingBankEntry},
+    solana_poh::poh_recorder::{PohRecorder/*, WorkingBankEntry*/},
     solana_rpc::{
         optimistically_confirmed_bank_tracker::BankNotificationSender,
         rpc_subscriptions::RpcSubscriptions,
@@ -57,7 +57,7 @@ pub struct TpuSockets {
     pub transactions: Vec<UdpSocket>,
     pub transaction_forwards: Vec<UdpSocket>,
     pub vote: Vec<UdpSocket>,
-    pub broadcast: Vec<UdpSocket>,
+    // pub broadcast: Vec<UdpSocket>,
     pub transactions_quic: Option<UdpSocket>,
     pub transactions_forwards_quic: Option<UdpSocket>,
 }
@@ -68,10 +68,10 @@ pub struct Tpu {
     vote_sigverify_stage: SigVerifyStage,
     banking_stage: BankingStage,
     cluster_info_vote_listener: ClusterInfoVoteListener,
-    broadcast_stage: BroadcastStage,
+    // broadcast_stage: BroadcastStage,
     tpu_quic_t: Option<thread::JoinHandle<()>>,
     tpu_forwards_quic_t: Option<thread::JoinHandle<()>>,
-    tpu_entry_notifier: Option<TpuEntryNotifier>,
+    // tpu_entry_notifier: Option<TpuEntryNotifier>,
     staked_nodes_updater_service: StakedNodesUpdaterService,
     tracer_thread_hdl: TracerThread,
 }
@@ -81,16 +81,16 @@ impl Tpu {
     pub fn new(
         cluster_info: &Arc<ClusterInfo>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
-        entry_receiver: Receiver<WorkingBankEntry>,
-        retransmit_slots_receiver: RetransmitSlotsReceiver,
+        // entry_receiver: Receiver<WorkingBankEntry>,
+        // retransmit_slots_receiver: RetransmitSlotsReceiver,
         sockets: TpuSockets,
         subscriptions: &Arc<RpcSubscriptions>,
         transaction_status_sender: Option<TransactionStatusSender>,
-        entry_notification_sender: Option<EntryNotifierSender>,
+        // entry_notification_sender: Option<EntryNotifierSender>,
         blockstore: &Arc<Blockstore>,
-        broadcast_type: &BroadcastStageType,
+        // broadcast_type: &BroadcastStageType,
         exit: &Arc<AtomicBool>,
-        shred_version: u16,
+        // shred_version: u16,
         vote_tracker: Arc<VoteTracker>,
         bank_forks: Arc<RwLock<BankForks>>,
         verified_vote_sender: VerifiedVoteSender,
@@ -116,7 +116,7 @@ impl Tpu {
             transactions: transactions_sockets,
             transaction_forwards: tpu_forwards_sockets,
             vote: tpu_vote_sockets,
-            broadcast: broadcast_sockets,
+            //broadcast: broadcast_sockets,
             transactions_quic: transactions_quic_sockets,
             transactions_forwards_quic: transactions_forwards_quic_sockets,
         } = sockets;
@@ -244,30 +244,30 @@ impl Tpu {
             firedancer_app_name,
         );
 
-        let (entry_receiver, tpu_entry_notifier) =
-            if let Some(entry_notification_sender) = entry_notification_sender {
-                let (broadcast_entry_sender, broadcast_entry_receiver) = unbounded();
-                let tpu_entry_notifier = TpuEntryNotifier::new(
-                    entry_receiver,
-                    entry_notification_sender,
-                    broadcast_entry_sender,
-                    exit.clone(),
-                );
-                (broadcast_entry_receiver, Some(tpu_entry_notifier))
-            } else {
-                (entry_receiver, None)
-            };
+        // let (entry_receiver, tpu_entry_notifier) =
+        //     if let Some(entry_notification_sender) = entry_notification_sender {
+        //         let (broadcast_entry_sender, broadcast_entry_receiver) = unbounded();
+        //         let tpu_entry_notifier = TpuEntryNotifier::new(
+        //             entry_receiver,
+        //             entry_notification_sender,
+        //             broadcast_entry_sender,
+        //             exit.clone(),
+        //         );
+        //         (broadcast_entry_receiver, Some(tpu_entry_notifier))
+        //     } else {
+        //         (entry_receiver, None)
+        //     };
 
-        let broadcast_stage = broadcast_type.new_broadcast_stage(
-            broadcast_sockets,
-            cluster_info.clone(),
-            entry_receiver,
-            retransmit_slots_receiver,
-            exit.clone(),
-            blockstore.clone(),
-            bank_forks,
-            shred_version,
-        );
+        // let broadcast_stage = broadcast_type.new_broadcast_stage(
+        //     broadcast_sockets,
+        //     cluster_info.clone(),
+        //     entry_receiver,
+        //     retransmit_slots_receiver,
+        //     exit.clone(),
+        //     blockstore.clone(),
+        //     bank_forks,
+        //     shred_version,
+        // );
 
         Self {
             fetch_stage,
@@ -275,10 +275,10 @@ impl Tpu {
             vote_sigverify_stage,
             banking_stage,
             cluster_info_vote_listener,
-            broadcast_stage,
+            // broadcast_stage,
             tpu_quic_t,
             tpu_forwards_quic_t,
-            tpu_entry_notifier,
+            // tpu_entry_notifier,
             staked_nodes_updater_service,
             tracer_thread_hdl,
         }
@@ -295,14 +295,14 @@ impl Tpu {
             self.tpu_quic_t.map_or(Ok(()), |x| x.join()),
             self.tpu_forwards_quic_t.map_or(Ok(()), |x| x.join()),
         ];
-        let broadcast_result = self.broadcast_stage.join();
+        // let broadcast_result = self.broadcast_stage.join();
         for result in results {
             result?;
         }
-        if let Some(tpu_entry_notifier) = self.tpu_entry_notifier {
-            tpu_entry_notifier.join()?;
-        }
-        let _ = broadcast_result?;
+        // if let Some(tpu_entry_notifier) = self.tpu_entry_notifier {
+        //     tpu_entry_notifier.join()?;
+        // }
+        // let _ = broadcast_result?;
         if let Some(tracer_thread_hdl) = self.tracer_thread_hdl {
             if let Err(tracer_result) = tracer_thread_hdl.join()? {
                 error!(

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -4,7 +4,7 @@
 use {
     crate::{
         banking_trace::BankingTracer,
-        broadcast_stage::RetransmitSlotsSender,
+        // broadcast_stage::RetransmitSlotsSender,
         cache_block_meta_service::CacheBlockMetaSender,
         cluster_info_vote_listener::{
             GossipDuplicateConfirmedSlotsReceiver, GossipVerifiedVoteHashReceiver,
@@ -122,7 +122,7 @@ impl Tvu {
         cache_block_meta_sender: Option<CacheBlockMetaSender>,
         entry_notification_sender: Option<EntryNotifierSender>,
         vote_tracker: Arc<VoteTracker>,
-        retransmit_slots_sender: RetransmitSlotsSender,
+        // retransmit_slots_sender: RetransmitSlotsSender,
         gossip_verified_vote_hash_receiver: GossipVerifiedVoteHashReceiver,
         verified_vote_receiver: VerifiedVoteReceiver,
         replay_vote_sender: ReplayVoteSender,
@@ -292,7 +292,7 @@ impl Tvu {
             maybe_process_block_store,
             vote_tracker,
             cluster_slots,
-            retransmit_slots_sender,
+            // retransmit_slots_sender,
             ancestor_duplicate_slots_receiver,
             replay_vote_sender,
             gossip_confirmed_slots_receiver,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -860,7 +860,7 @@ impl Validator {
         );
 
         let startup_verification_complete;
-        let (poh_recorder, entry_receiver, record_receiver) = {
+        let (poh_recorder, /* entry_receiver, */ record_receiver) = {
             let bank = &bank_forks.read().unwrap().working_bank();
             startup_verification_complete = Arc::clone(bank.get_startup_verification_complete());
             PohRecorder::new_with_clear_signal(
@@ -1086,7 +1086,7 @@ impl Validator {
 
         let vote_tracker = Arc::<VoteTracker>::default();
 
-        let (retransmit_slots_sender, retransmit_slots_receiver) = unbounded();
+        // let (retransmit_slots_sender, retransmit_slots_receiver) = unbounded();
         let (verified_vote_sender, verified_vote_receiver) = unbounded();
         let (gossip_verified_vote_hash_sender, gossip_verified_vote_hash_receiver) = unbounded();
         let (cluster_confirmed_slot_sender, cluster_confirmed_slot_receiver) = unbounded();
@@ -1144,7 +1144,7 @@ impl Validator {
             cache_block_meta_sender,
             entry_notification_sender.clone(),
             vote_tracker.clone(),
-            retransmit_slots_sender,
+            // retransmit_slots_sender,
             gossip_verified_vote_hash_receiver,
             verified_vote_receiver,
             replay_vote_sender.clone(),
@@ -1173,23 +1173,23 @@ impl Validator {
         let tpu = Tpu::new(
             &cluster_info,
             &poh_recorder,
-            entry_receiver,
-            retransmit_slots_receiver,
+            // entry_receiver,
+            // retransmit_slots_receiver,
             TpuSockets {
                 transactions: node.sockets.tpu,
                 transaction_forwards: node.sockets.tpu_forwards,
                 vote: node.sockets.tpu_vote,
-                broadcast: node.sockets.broadcast,
+                // broadcast: node.sockets.broadcast,
                 transactions_quic: node.sockets.tpu_quic,
                 transactions_forwards_quic: node.sockets.tpu_forwards_quic,
             },
             &rpc_subscriptions,
             transaction_status_sender,
-            entry_notification_sender,
+            // entry_notification_sender,
             &blockstore,
-            &config.broadcast_stage_type,
+            // &config.broadcast_stage_type,
             &exit,
-            node.info.shred_version(),
+            // node.info.shred_version(),
             vote_tracker,
             bank_forks.clone(),
             verified_vote_sender,
@@ -1271,15 +1271,15 @@ impl Validator {
             "local gossip address: {}",
             node.sockets.gossip.local_addr().unwrap()
         );
-        info!(
-            "local broadcast address: {}",
-            node.sockets
-                .broadcast
-                .first()
-                .unwrap()
-                .local_addr()
-                .unwrap()
-        );
+        // info!(
+        //     "local broadcast address: {}",
+        //     node.sockets
+        //         .broadcast
+        //         .first()
+        //         .unwrap()
+        //         .local_addr()
+        //         .unwrap()
+        // );
         info!(
             "local repair address: {}",
             node.sockets.repair.local_addr().unwrap()

--- a/firedancer/src/dcache.rs
+++ b/firedancer/src/dcache.rs
@@ -6,9 +6,15 @@ use crate::*;
 
 pub struct DCache {
     laddr: *mut u8,
+    chunk0: u64,
+    wmark: u64,
+    chunk: u64,
     wksp: *mut util::fd_wksp_t,
     _workspace: Workspace,
 }
+
+unsafe impl Sync for DCache {}
+unsafe impl Send for DCache {}
 
 impl Drop for DCache {
     fn drop(&mut self) {
@@ -17,7 +23,7 @@ impl Drop for DCache {
 }
 
 impl DCache {
-    pub unsafe fn join<T: Into<GlobalAddress>>(gaddr: T) -> Result<Self, ()> {
+    pub unsafe fn join<T: Into<GlobalAddress>>(gaddr: T, mtu: u64) -> Result<Self, ()> {
       let workspace = Workspace::map(gaddr)?;
       let laddr = tango::fd_dcache_join(workspace.laddr.as_ptr());
       if laddr.is_null() {
@@ -25,15 +31,31 @@ impl DCache {
       }
 
       let wksp = util::fd_wksp_containing(laddr as *const c_void);
+      let chunk0 = tango::fd_dcache_compact_chunk0(wksp as *const c_void, laddr as *const c_void);
       Ok(Self {
           laddr,
+          chunk0,
+          wmark: tango::fd_dcache_compact_wmark(wksp  as *const c_void, laddr  as *const c_void, mtu),
+          chunk: chunk0,
           wksp,
           _workspace: workspace,
       })
   }
 
+  pub fn chunk(&self) -> u64 {
+    self.chunk
+  }
+
   pub unsafe fn slice<'a>(&self, chunk: u64, offset: u64, len: u64) -> &'a[u8] {
     let laddr = tango::fd_chunk_to_laddr_const(self.wksp as *const c_void, chunk);
     std::slice::from_raw_parts(laddr.offset(offset as isize) as *const u8, len as usize)
+  }
+
+  pub unsafe fn write<'a>(&mut self, len: usize) -> &'a mut [u8] {
+    std::slice::from_raw_parts_mut(tango::fd_chunk_to_laddr(self.wksp as *mut c_void, self.chunk) as *mut u8, len)
+  }
+
+  pub unsafe fn compact_next(&mut self, sz: u64) {
+    self.chunk = tango::fd_dcache_compact_next(self.chunk, sz, self.chunk0, self.wmark)
   }
 }

--- a/firedancer/src/fctl.rs
+++ b/firedancer/src/fctl.rs
@@ -36,6 +36,9 @@ pub struct FCtl<'a, 'b> {
     _slow: PhantomData<&'b mut u64>,
 }
 
+unsafe impl<'a, 'b> Sync for FCtl<'a, 'b> {}
+unsafe impl<'a, 'b> Send for FCtl<'a, 'b> {}
+
 impl<'a, 'b> Drop for FCtl<'a, 'b> {
     fn drop(&mut self) {
         unsafe { tango::fd_fctl_leave(self.fctl) };

--- a/firedancer/src/mcache.rs
+++ b/firedancer/src/mcache.rs
@@ -17,6 +17,9 @@ pub struct MCache {
     _workspace: Workspace,
 }
 
+unsafe impl Sync for MCache {}
+unsafe impl Send for MCache {}
+
 #[derive(Copy, Clone)]
 pub enum MCacheCtl {
     None

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2836,7 +2836,7 @@ pub struct Sockets {
     pub tpu: Vec<UdpSocket>,
     pub tpu_forwards: Vec<UdpSocket>,
     pub tpu_vote: Vec<UdpSocket>,
-    pub broadcast: Vec<UdpSocket>,
+    // pub broadcast: Vec<UdpSocket>,
     pub repair: UdpSocket,
     pub retransmit_sockets: Vec<UdpSocket>,
     pub serve_repair: UdpSocket,
@@ -2877,7 +2877,7 @@ impl Node {
         let rpc_addr = SocketAddr::new(localhost_ip_addr, rpc_port);
         let rpc_pubsub_port = find_available_port_in_range(localhost_ip_addr, port_range).unwrap();
         let rpc_pubsub_addr = SocketAddr::new(localhost_ip_addr, rpc_pubsub_port);
-        let broadcast = vec![UdpSocket::bind(&unspecified_bind_addr).unwrap()];
+        // let broadcast = vec![UdpSocket::bind(&unspecified_bind_addr).unwrap()];
         let retransmit_socket = UdpSocket::bind(&unspecified_bind_addr).unwrap();
         let serve_repair = UdpSocket::bind(&localhost_bind_addr).unwrap();
         let ancestor_hashes_requests = UdpSocket::bind(&unspecified_bind_addr).unwrap();
@@ -2927,7 +2927,7 @@ impl Node {
                 tpu: vec![tpu],
                 tpu_forwards: vec![tpu_forwards],
                 tpu_vote: vec![tpu_vote],
-                broadcast,
+                // broadcast,
                 repair,
                 retransmit_sockets: vec![retransmit_socket],
                 serve_repair,
@@ -2976,7 +2976,7 @@ impl Node {
         let (_, retransmit_socket) = Self::bind(bind_ip_addr, port_range);
         let (repair_port, repair) = Self::bind(bind_ip_addr, port_range);
         let (serve_repair_port, serve_repair) = Self::bind(bind_ip_addr, port_range);
-        let (_, broadcast) = Self::bind(bind_ip_addr, port_range);
+        // let (_, broadcast) = Self::bind(bind_ip_addr, port_range);
         let (_, ancestor_hashes_requests) = Self::bind(bind_ip_addr, port_range);
 
         let rpc_port = find_available_port_in_range(bind_ip_addr, port_range).unwrap();
@@ -3018,7 +3018,7 @@ impl Node {
                 tpu: vec![tpu],
                 tpu_forwards: vec![tpu_forwards],
                 tpu_vote: vec![tpu_vote],
-                broadcast: vec![broadcast],
+                // broadcast: vec![broadcast],
                 repair,
                 retransmit_sockets: vec![retransmit_socket],
                 serve_repair,
@@ -3077,8 +3077,8 @@ impl Node {
         let (repair_port, repair) = Self::bind(bind_ip_addr, port_range);
         let (serve_repair_port, serve_repair) = Self::bind(bind_ip_addr, port_range);
 
-        let (_, broadcast) =
-            multi_bind_in_range(bind_ip_addr, port_range, 4).expect("broadcast multi_bind");
+        // let (_, broadcast) =
+        //     multi_bind_in_range(bind_ip_addr, port_range, 4).expect("broadcast multi_bind");
 
         let (_, ancestor_hashes_requests) = Self::bind(bind_ip_addr, port_range);
 
@@ -3109,7 +3109,7 @@ impl Node {
                 tpu: vec![], // tpu_sockets,
                 tpu_forwards: vec![], // tpu_forwards_sockets,
                 tpu_vote: vec![], // tpu_vote_sockets,
-                broadcast,
+                // broadcast,
                 repair,
                 retransmit_sockets,
                 serve_repair,

--- a/poh/Cargo.toml
+++ b/poh/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+bincode = { workspace = true }
 core_affinity = { workspace = true }
 crossbeam-channel = { workspace = true }
 log = { workspace = true }

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -101,7 +101,7 @@ fn verify_reachable_ports(
     }
     if verify_address(&node.info.tvu(Protocol::UDP).ok()) {
         udp_sockets.extend(node.sockets.tvu.iter());
-        udp_sockets.extend(node.sockets.broadcast.iter());
+        // udp_sockets.extend(node.sockets.broadcast.iter());
         udp_sockets.extend(node.sockets.retransmit_sockets.iter());
     }
     if verify_address(&node.info.tvu_forwards().ok()) {


### PR DESCRIPTION
The POH recorder is changed to send directly to Firedancer via. a new mcache / dcache pair. There is some unpleasantness in this,

 (a) We serialize on the poh recorder thread. This acutally doesn't
     matter so much, since it's similar cost to a memcpy and the
     poh recorder sleeps a lot due to having spare cycles.

 (b) We can backpressure the thread, which would cause it to fall
     behind. There's not really a good solution here. Solana just uses
     an infinite buffer size for this channel.

But then there's major pleasantness as well, mainly that we save some copies of the data across crossbeam channels.

In the process of removing all the wiring, we also saw and subsequently removed the `maybe_retransmit_unpropagated_slots` functionality from the replay stage. This is considered "band-aid" functionality and is potentially being removed from Solana Labs, so we choose to remove it rather than plumb this channel through to our shred stage as well. See https://github.com/solana-labs/solana/issues/30098