### PR TITLE
Force static linkage of locally compiled libbz2

### DIFF
--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -16,7 +16,7 @@ blake3 = { workspace = true }
 bv = { workspace = true, features = ["serde"] }
 bytemuck = { workspace = true }
 byteorder = { workspace = true }
-bzip2 = { workspace = true }
+bzip2 = { workspace = true, features = ["static"] }
 crossbeam-channel = { workspace = true }
 dashmap = { workspace = true, features = ["rayon", "raw-api"] }
 flate2 = { workspace = true }

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -12,7 +12,7 @@ edition = { workspace = true }
 [dependencies]
 atty = { workspace = true }
 bincode = { workspace = true }
-bzip2 = { workspace = true }
+bzip2 = { workspace = true, features = ["static"] }
 chrono = { workspace = true, features = ["default", "serde"] }
 clap = { workspace = true }
 console = { workspace = true }

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -75,7 +75,7 @@ solana-firedancer = { workspace = true }
 # when also using the bzip2 crate
 version = "0.21.0"
 default-features = false
-features = ["lz4"]
+features = ["bzip2", "lz4"]
 
 [dev-dependencies]
 bs58 = { workspace = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -17,7 +17,7 @@ blake3 = { workspace = true }
 bv = { workspace = true, features = ["serde"] }
 bytemuck = { workspace = true }
 byteorder = { workspace = true }
-bzip2 = { workspace = true }
+bzip2 = { workspace = true, features = ["static"] }
 crossbeam-channel = { workspace = true }
 dashmap = { workspace = true, features = ["rayon", "raw-api"] }
 dir-diff = { workspace = true }

--- a/sdk/cargo-build-sbf/Cargo.toml
+++ b/sdk/cargo-build-sbf/Cargo.toml
@@ -10,7 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-bzip2 = { workspace = true }
+bzip2 = { workspace = true, features = ["static"] }
 cargo_metadata = { workspace = true }
 clap = { version = "3.1.5", features = ["cargo", "env"] }
 itertools = { workspace = true }

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -13,7 +13,7 @@ edition = { workspace = true }
 backoff = { workspace = true, features = ["tokio"] }
 bincode = { workspace = true }
 bytes = { workspace = true }
-bzip2 = { workspace = true }
+bzip2 = { workspace = true, features = ["static"] }
 enum-iterator = { workspace = true }
 flate2 = { workspace = true }
 futures = { workspace = true }


### PR DESCRIPTION
The libbz2-sys crate will attempt to discover a system libbz2 via pkg-config. If found, libbz2 will not be compiled as part of the cargo build process.

However, Firedancer's build system will never link bz2 regardless of what cargo build does.

This will cause link errors regarding missing libbz2 symbols depending on the system's pkg-config.

Cargo's bizarre feature system does not allow the user to directly control the way libbz2 is linked. Instead, every crate dependent on libbz2 will have to plumb down the `static` feature down to libbz2. (e.g. rocksdb => librocksdb-sys => bzip2-sys)

In another bizarre twist, the `rocksdb` crate even with default features disabled, will add libz and libbz2 crates, without the static features. Thus, we add back the `bzip2` feature to RocksDB - Which somehow fixes this behavior.